### PR TITLE
feat(orders): Added total amount to the order df

### DIFF
--- a/pyhomebroker/__init__.py
+++ b/pyhomebroker/__init__.py
@@ -19,8 +19,7 @@
 # limitations under the License.
 #
 
-__version__ = '0.50'
+__version__ = '0.51'
 __author__ = 'Diego Degese'
 
 from .home_broker import HomeBroker
-

--- a/pyhomebroker/orders/orders.py
+++ b/pyhomebroker/orders/orders.py
@@ -50,10 +50,8 @@ class Orders:
     }
 
     __orders_status_index = ['order_number']
-    __orders_status_columns = [
-        'order_number', 'symbol', 'settlement', 'operation_type', 'size',
-        'price', 'remaining_size', 'total', 'datetime', 'status', 'cancellable'
-    ]
+    __orders_status_columns = ['order_number', 'symbol', 'settlement', 'operation_type', 'size', 'price', 'remaining_size', 'datetime', 'status', 'cancellable', 'total']
+    __empty_orders_status = pd.DataFrame(columns=__orders_status_columns).set_index(__orders_status_index)
 
     __orders_send_lock = Lock()
 
@@ -343,7 +341,7 @@ class Orders:
         if not orders:
             return self.__empty_orders_status
 
-        filter_columns = ['NUME', 'TICK', 'PLAZ', 'TIPO', 'CANT', 'PCIO', 'REMN', 'FALT', 'TOTAL', 'ESTA', 'CanCancel']
+        filter_columns = ['NUME', 'TICK', 'PLAZ', 'TIPO', 'CANT', 'PCIO', 'REMN', 'FALT', 'ESTA', 'CanCancel', 'TOTAL']
         numeric_columns = ['order_number', 'size', 'price', 'remaining_size', 'total']
 
         df = pd.DataFrame()
@@ -352,13 +350,13 @@ class Orders:
 
             df_order = pd.DataFrame([order])
             df_order['REMN'] = pd.to_numeric(df_order.CANT)
-            df_order['TOTAL'] = 0
+            df_order['TOTAL'] = pd.to_numeric(df_order.IMPO)
             if order['APLI']:
                 df_operations = pd.DataFrame(order['APLI'])
                 df_operations.CANT = pd.to_numeric(df_operations.CANT)
-                df_operations.TOTAL = df_operations['CANT', 'IMPO'].prod(axis=1)
+                df_operations.IMPO = pd.to_numeric(df_operations.IMPO)
                 df_order.REMN = df_order.REMN - df_operations.CANT.sum()
-                df_order.TOTAL += df_operations.TOTAL.sum()
+                df_order.TOTAL = df_operations.IMPO.sum()
 
             df = df_order if df.empty else pd.concat([df, df_order])
 


### PR DESCRIPTION
#### What does this PR do?

- [x] I added a new column in the orders data frame with the total amount resulting from the order operations (partial and total

#### Where should the reviewer start?
Calc of the new column [here](https://github.com/crapher/pyhomebroker/compare/main...lisandro:pyhomebroker:feat/orders-total?expand=1#diff-e179b15da341bf9c99a74742c006c943abd997a951315ae2e54e00258cf010d1R359)
#### How should this be manually tested?

Having an order with partial operations with different prices the sum of each should be the resulting value of this new column.

#### Any background context you want to provide?
I saw that HB does not sum correctly the total of each operation where there were different prices from the order price, so.

Example:
- Order type: Sell
- Order price: 100
- Order qty: 10
- Operations
1. Sell: 5 @ 102
2. Sell 5 @ 101

- Expected total: 1015
- Current total in HB: 1000

#### What are the relevant tickets?
NA
#### Screenshots (if appropriate)

- In HB we can see that total is not correct when the
<img width="328" alt="Screen Shot 2022-07-18 at 19 00 11" src="https://user-images.githubusercontent.com/4897773/179624789-a4a58c06-9e06-43a6-afad-f73fcd14c858.png">
 operations had a better price 

We can see that the data frame has the correct value for operated values
```
             symbol settlement operation_type  size    price  remaining_size            datetime     status  cancellable       total
order_number                                                                                                                        
XXXX        AY24       48hs           SELL   696  5224.00               0 2020-01-10 11:43:47  COMPLETED        False   36366.000
```

#### Questions 

- I would like to discuss the name of the column to follow a naming convention and maybe put it at the end to avoid breaking changes for users accessing to column index